### PR TITLE
Fix wrong header size

### DIFF
--- a/extractor.c
+++ b/extractor.c
@@ -238,7 +238,7 @@ int GetPictureEx(size_t data_size, HANDLE *bitmap_info, HANDLE *bitmap_data,
 		LocalFree(*bitmap_data);
 		return SPI_MEMORY_ERROR;
 	}
-	bitmap_info_locked->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bitmap_info_locked->bmiHeader.biSize = sizeof(BITMAPINFO);
 	bitmap_info_locked->bmiHeader.biWidth = bitmap_info_header.biWidth;
 	bitmap_info_locked->bmiHeader.biHeight = bitmap_info_header.biHeight;
 	bitmap_info_locked->bmiHeader.biPlanes = 1;


### PR DESCRIPTION
There was a missing correction in the fix for Pull Request #3. I had allocated memory with a size of `sizeof(BITMAPINFO)` bytes, but forgot to update the size stored in the header accordingly. This has now been fixed.